### PR TITLE
fix(android): add dash, hls, and smoothstreaming support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,6 +79,10 @@ dependencies {
 	implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
 	implementation "androidx.media3:media3-exoplayer:1.6.0"
+	implementation "androidx.media3:media3-exoplayer-hls:1.6.0"
+	implementation "androidx.media3:media3-exoplayer-dash:1.6.0"
+	implementation "androidx.media3:media3-exoplayer-smoothstreaming:1.6.0"
+	
 	implementation "androidx.media3:media3-session:1.6.0"
 	implementation "androidx.media3:media3-common:1.6.0"
 	implementation "androidx.media3:media3-common-ktx:1.6.0"


### PR DESCRIPTION
This fixes the issue of HLS, DASH, and SmoothStreaming not working by adding the processing libraries needed for them to the library gradle.