### PR TITLE
Fixes NativeEventEmitter() showing up on Expo (IOS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.0.2",
   "description": "A React Native module for audio playback from remote URLs, ideal for audiobook and podcast apps, with background playback, lock screen notification controls on Android, iOS, and web.",
   "source": "./src/index",
+  "react-native": "./src/index",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",
   "scripts": {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -1,12 +1,11 @@
-import { NativeEventEmitter } from 'react-native';
-import type { AudioProEvent } from './types';
-import { logDebug } from './utils';
+import { NativeModules, NativeEventEmitter } from 'react-native';
 import { useInternalStore } from './useInternalStore';
-import { NativeAudioPro } from './index';
+import { logDebug } from './utils';
 
-export const emitter = new NativeEventEmitter(NativeAudioPro);
+const AudioPro = NativeModules.AudioPro;
+export const emitter = new NativeEventEmitter(AudioPro);
 
-emitter.addListener('AudioProEvent', (event: AudioProEvent) => {
+emitter.addListener('AudioProEvent', (event) => {
 	logDebug('AudioProEvent', JSON.stringify(event));
 	useInternalStore.getState().updateFromEvent(event);
 });


### PR DESCRIPTION
react native reads the react-native field first in package.json, so you need to add the react-native field. 

I also confirmed that it works fine on Expo.
