### PR TITLE
fix(ios): Correct float casting for Double values in .play() method

### DIFF
--- a/ios/AudioPro.swift
+++ b/ios/AudioPro.swift
@@ -285,8 +285,8 @@ class AudioPro: RCTEventEmitter {
 		currentTrack = track
 		settingDebug = options["debug"] as? Bool ?? false
 		settingDebugIncludeProgress = options["debugIncludesProgress"] as? Bool ?? false
-		let speed = options["playbackSpeed"] as? Float ?? 1.0
-		let volume = options["volume"] as? Float ?? 1.0
+		let speed = Float(options["playbackSpeed"] as? Double ?? 1.0)
+		let volume = Float(options["volume"] as? Double ?? 1.0)
 		let autoPlay = options["autoPlay"] as? Bool ?? true
 		settingShowNextPrevControls = options["showNextPrevControls"] as? Bool ?? true
 		pendingStartTimeMs = options["startTimeMs"] as? Double


### PR DESCRIPTION
## Description
Attempted cast to `Float` would fail because `volume` and `playbackSpeed` are of type `Double` and their values would default to `1.0` even when those values were manually set right before calling `.play()`.

## How to test
1. pull changes and build the example app
2. change volume value
3. press the play button
4. the track should play with expected volume value

## Additional notes
I've also noticed a few issues with the `playbackSpeed` parameter.
1. Pressing the increase/decrease playbackSpeed button will automatically play the audio without affecting the javascript state (i.e. you change the playback speed -> the audio starts playing -> the UI still shows "play (track)".
2. Similarly to the issue being fixed in this PR, when setting a default playback speed value before calling the `.play` method does not affect the initial speed at which the audio will play (it will always default to 1.0).
I'm not 100% sure, but I think it has something to do with this line: `MPNowPlayingInfoCenter.default().nowPlayingInfo = currentInfo`, for some reason it's not actually updating with the new value (after debugging, I'm able to see that `currentInfo` gets mutated with the proper playbackSpeed value...)
3. I've also noticed the function `resume` resets the `rate` to `1.0` as you can see here: `updateNowPlayingInfo(time: player?.currentTime().seconds ?? 0, rate: 1.0)` I was a bit confused by that as we're not resetting the playback volume on `resume`, I was curious to understand the rational behind this decision.