### PR TITLE
fix: foreground service on android

### DIFF
--- a/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProPlaybackService.kt
+++ b/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProPlaybackService.kt
@@ -75,12 +75,29 @@ open class AudioProPlaybackService : MediaLibraryService() {
 	@OptIn(UnstableApi::class) // MediaSessionService.setListener
 	override fun onCreate() {
 		super.onCreate()
+		startForegroundService()
 		initializeSessionAndPlayer()
 		setListener(MediaSessionServiceListener())
 	}
 
 	override fun onGetSession(controllerInfo: ControllerInfo): MediaLibrarySession {
 		return mediaLibrarySession
+	}
+
+	private fun startForegroundService() {
+    val notificationManagerCompat = NotificationManagerCompat.from(this)
+    ensureNotificationChannel(notificationManagerCompat)
+    
+    val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+        .setSmallIcon(android.R.drawable.ic_media_play) // Use a default system icon
+        .setContentTitle("Audio Pro")
+        .setContentText("Playing audio")
+        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+        .setOngoing(true)
+        .setAutoCancel(false)
+        .also { builder -> getBackStackedActivity()?.let { builder.setContentIntent(it) } }
+    
+    startForeground(1, builder.build())
 	}
 
 	/**


### PR DESCRIPTION
This code should fix it, I didn't see it happening anymore after implementing this fix:

To reproduce the issue, just spam the adb shell and have the adb logcat to catch the error:

adb shell am start-foreground-service audiopro.example/dev.rnap.reactnativeaudiopro.AudioProPlaybackService

adb logcat | grep -E "(AudioProPlaybackService|startForeground|FATAL|AndroidRuntime|Context.startForegroundService)" --color=always