### PR TITLE
docs: fix a couple of broken readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Modern, background-capable audio playback for React Native — built for podcast
 - [🔧 Add-On Features](#-add-on-features)
 - [⚙️ Requirements](#-requirements)
 - [🚀 Installation](#-installation)
-- [📦 Expo Integration](#-expo-integration)
-- [📚 API Overview](#api-overview)
+- [📦 Expo Installation](#-expo-installation)
+- [📚 API Overview](#-api-overview)
 - [⚡️ useAudioPro Hook Example](#useaudiopro-hook-example)
-- [📦 API Usage Example](#api-usage-example)
+- [📦 API Usage Example](#-api-usage-example)
 - [🔊 Ambient Audio](#-ambient-audio)
 - [📱 Example App](#-example-app)
-- [🤝 Contributing](#contributing)
+- [🤝 Contributing](CONTRIBUTING.md)
 
 ## ✅ Core Features
 


### PR DESCRIPTION
I noticed a few of the anchors in the table of contents are broken. This PR doesn't fix all of them (_Requirements_ and _useAudioPro Hook Example_ are still broken), though as best as I can tell, this is something wrong with Github's markdown renderer. 

Most importantly I wanted to fix the link to `CONTRIBUTING.md`, though :slightly_smiling_face: 