### PR TITLE
Feat: deprecate skipInterval and replace with skipIntervalMs method

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ AudioPro.configure({
   contentType: AudioProContentType.MUSIC,
   showNextPrevControls: true, // Hide next/previous buttons
   showSkipControls: false,      // Show skip/seek forward/back buttons (default: true)
-  skipInterval: 30,            // Number of seconds for skip/seek (default: 30)
+  skipIntervalMs: 30000,            // Number of milliseconds for skip forward/back controls (default: 30000)
 });
 ```
 
@@ -243,8 +243,8 @@ AudioPro.configure({
   If your app only plays single tracks, set to `false`.
 - `showSkipControls` — Show skip/seek forward/backward buttons (default: `false`).
   If enabled, lock screen and notification controls will include skip forward/backward (seek) buttons.
-- `skipInterval` — The interval (in seconds) used for skip forward/back controls.
-  If not set, defaults to 30 seconds.
+- `skipIntervalMs` — The interval (in milliseconds) used for skip forward/back controls.
+  If not set, defaults to 30000 (30 seconds).
 
 > ⚠️ **Only one set of controls can be active at a time.**
 > If both `showNextPrevControls` and `showSkipControls` are set to `true`, only Next/Prev controls will be shown (Skip controls will be ignored).
@@ -256,7 +256,7 @@ AudioPro.configure({
   contentType: AudioProContentType.SPEECH,
   showNextPrevControls: false,
   showSkipControls: true,      // Only show skip/seek buttons
-  skipInterval: 15,            // 15 second skip
+  skipIntervalMs: 15000,       // 15 second skip
 });
 ```
 
@@ -300,7 +300,7 @@ type AudioProSetupOptions = {
     progressIntervalMs?: number;       // Frequency (in ms) for PROGRESS events (default: 1000ms)
     showNextPrevControls?: boolean;    // Show next/previous buttons (default: true)
     showSkipControls?: boolean;        // Show skip/seek forward/back buttons (default: true)
-    skipInterval?: number;             // Skip interval in seconds (default: 30)
+    skipIntervalMs?: number;           // Interval in milliseconds for skip forward/back controls (default: 30000)
 };
 
 type AudioProPlayOptions = {

--- a/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProController.kt
+++ b/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProController.kt
@@ -46,7 +46,7 @@ object AudioProController {
 	var settingAudioContentType: Int = C.AUDIO_CONTENT_TYPE_MUSIC
 	var settingShowNextPrevControls: Boolean = true
 	var settingShowSkipControls: Boolean = false
-	var settingSkipIntervalMs: Long = 10000L
+	var settingSkipIntervalMs: Long = 30000L
 
 	var headersAudio: Map<String, String>? = null
 	var headersArtwork: Map<String, String>? = null
@@ -123,7 +123,7 @@ object AudioProController {
 		val showSkip =
 			if (options.hasKey("showSkipControls")) options.getBoolean("showSkipControls") else true
 		val skipIntervalMs =
-			if (options.hasKey("skipIntervalMs")) options.getDouble("skipIntervalMs").toLong() else 10000L
+			if (options.hasKey("skipIntervalMs")) options.getDouble("skipIntervalMs").toLong() else 30000L
 
 		// Warn if showNextPrevControls is changed after session initialization
 		if (::engineBrowserFuture.isInitialized && enginerBrowser != null && showControls != settingShowNextPrevControls) {

--- a/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProController.kt
+++ b/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProController.kt
@@ -46,7 +46,7 @@ object AudioProController {
 	var settingAudioContentType: Int = C.AUDIO_CONTENT_TYPE_MUSIC
 	var settingShowNextPrevControls: Boolean = true
 	var settingShowSkipControls: Boolean = false
-	var settingSkipIntervalSeconds: Double = 10.0
+	var settingSkipIntervalMs: Long = 10000L
 
 	var headersAudio: Map<String, String>? = null
 	var headersArtwork: Map<String, String>? = null
@@ -97,7 +97,7 @@ object AudioProController {
 		val progressIntervalMs: Long,
 		val showNextPrevControls: Boolean,
 		val showSkipControls: Boolean,
-		val skipInterval: Double,
+		val skipIntervalMs: Long,
 	)
 
 	// Extracts and applies play options from JS before playback
@@ -122,8 +122,8 @@ object AudioProController {
 			if (options.hasKey("showNextPrevControls")) options.getBoolean("showNextPrevControls") else true
 		val showSkip =
 			if (options.hasKey("showSkipControls")) options.getBoolean("showSkipControls") else true
-		val skipInterval =
-			if (options.hasKey("skipInterval")) options.getDouble("skipInterval") else 10.0
+		val skipIntervalMs =
+			if (options.hasKey("skipIntervalMs")) options.getDouble("skipIntervalMs").toLong() else 10000L
 
 		// Warn if showNextPrevControls is changed after session initialization
 		if (::engineBrowserFuture.isInitialized && enginerBrowser != null && showControls != settingShowNextPrevControls) {
@@ -164,7 +164,7 @@ object AudioProController {
 		settingProgressIntervalMs = progressInterval
 		settingShowNextPrevControls = resolvedShowNextPrev
 		settingShowSkipControls = resolvedShowSkip
-		settingSkipIntervalSeconds = skipInterval
+		settingSkipIntervalMs = skipIntervalMs
 
 		return PlaybackOptions(
 			contentType,
@@ -177,7 +177,7 @@ object AudioProController {
 			progressInterval,
 			resolvedShowNextPrev,
 			resolvedShowSkip,
-			skipInterval,
+			skipIntervalMs,
 		)
 	}
 
@@ -226,7 +226,7 @@ object AudioProController {
 				"progressIntervalMs=${opts.progressIntervalMs} " +
 				"showNextPrevControls=${opts.showNextPrevControls} " +
 				"showSkipControls=${opts.showSkipControls} " +
-				"skipInterval=${opts.skipInterval}"
+				"skipIntervalMs=${opts.skipIntervalMs}"
 		)
 
 		val url = track.getString("url") ?: run {

--- a/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProMediaLibrarySessionCallback.kt
+++ b/android/src/main/java/dev/rnap/reactnativeaudiopro/AudioProMediaLibrarySessionCallback.kt
@@ -134,14 +134,12 @@ open class AudioProMediaLibrarySessionCallback : MediaLibraryService.MediaLibrar
 			}
 
 			CUSTOM_COMMAND_SKIP_FORWARD -> {
-				val skipAmountMs = (AudioProController.settingSkipIntervalSeconds * 1000).toLong()
-				AudioProController.seekForward(skipAmountMs)
+				AudioProController.seekForward(AudioProController.settingSkipIntervalMs)
 				return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
 			}
 
 			CUSTOM_COMMAND_SKIP_BACKWARD -> {
-				val skipAmountMs = (AudioProController.settingSkipIntervalSeconds * 1000).toLong()
-				AudioProController.seekBack(skipAmountMs)
+				AudioProController.seekBack(AudioProController.settingSkipIntervalMs)
 				return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
 			}
 		}

--- a/example/src/player-service.ts
+++ b/example/src/player-service.ts
@@ -20,7 +20,7 @@ export function setupAudioPro(): void {
 		progressIntervalMs: 1000,
 		showNextPrevControls: true,
 		showSkipControls: false,
-		skipInterval: 30,
+		skipIntervalMs: 30000,
 	});
 
 	// Set up event listeners that persist for the app's lifetime

--- a/ios/AudioPro.swift
+++ b/ios/AudioPro.swift
@@ -71,7 +71,7 @@ class AudioPro: RCTEventEmitter {
 	private var lastEmittedState: String = ""
 	private var wasPlayingBeforeInterruption: Bool = false
 	private var pendingStartTimeMs: Double? = nil
-	private var settingSkipIntervalMs: Double = 10000.0
+	private var settingSkipIntervalMs: Double = 30000.0
 
 	////////////////////////////////////////////////////////////
 	// MARK: - React Native Event Emitter Overrides

--- a/ios/AudioPro.swift
+++ b/ios/AudioPro.swift
@@ -71,7 +71,7 @@ class AudioPro: RCTEventEmitter {
 	private var lastEmittedState: String = ""
 	private var wasPlayingBeforeInterruption: Bool = false
 	private var pendingStartTimeMs: Double? = nil
-	private var settingSkipIntervalSeconds: Double = 10.0
+	private var settingSkipIntervalMs: Double = 10000.0
 
 	////////////////////////////////////////////////////////////
 	// MARK: - React Native Event Emitter Overrides
@@ -298,9 +298,9 @@ class AudioPro: RCTEventEmitter {
 		settingShowSkipControls = options["showSkipControls"] as? Bool ?? false
 		pendingStartTimeMs = options["startTimeMs"] as? Double
 
-		if let skipInterval = options["skipInterval"] as? Double {
-			settingSkipIntervalSeconds = skipInterval
-			log("Skip interval set to", settingSkipIntervalSeconds, "seconds")
+		if let skipIntervalMs = options["skipIntervalMs"] as? Double {
+			settingSkipIntervalMs = skipIntervalMs
+			log("Skip interval set to", settingSkipIntervalMs, "milliseconds")
 		}
 
 		if let progressIntervalMs = options["progressIntervalMs"] as? Double {
@@ -1111,15 +1111,13 @@ class AudioPro: RCTEventEmitter {
 		// Register command targets as before (disabling just hides/prevents UI, targets are safe to always register)
 		commandCenter.skipForwardCommand.addTarget { [weak self] event in
 			guard let self = self else { return .commandFailed }
-			let skipIntervalMs = self.settingSkipIntervalSeconds * 1000
-			self.seekForward(amount: skipIntervalMs)
+			self.seekForward(amount: self.settingSkipIntervalMs)
 			return .success
 		}
 
 		commandCenter.skipBackwardCommand.addTarget { [weak self] event in
 			guard let self = self else { return .commandFailed }
-			let skipIntervalMs = self.settingSkipIntervalSeconds * 1000
-			self.seekBack(amount: skipIntervalMs)
+			self.seekBack(amount: self.settingSkipIntervalMs)
 			return .success
 		}
 
@@ -1193,8 +1191,8 @@ class AudioPro: RCTEventEmitter {
 			return .success
 		}
 
-		commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: settingSkipIntervalSeconds)]
-		commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: settingSkipIntervalSeconds)]
+		commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: settingSkipIntervalMs)]
+		commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: settingSkipIntervalMs)]
 
 		isRemoteCommandCenterSetup = true
 	}

--- a/src/audioPro.ts
+++ b/src/audioPro.ts
@@ -56,7 +56,7 @@ export const AudioPro = {
 	 * @param options.debug - Enable debug logging
 	 * @param options.debugIncludesProgress - Include progress events in debug logs
 	 * @param options.progressIntervalMs - Interval in milliseconds for progress events
-	 * @param options.skipInterval - Skip interval in seconds
+	 * @param options.skipIntervalMs - Interval in milliseconds for skip forward/back actions
 	 * @param options.showNextPrevControls - Whether to show next/previous controls in notification
 	 * @param options.showSkipControls - Whether to show skip forward/back controls in notification
 	 */
@@ -81,6 +81,15 @@ export const AudioPro = {
 				'[react-native-audio-pro]: showNextPrevControls and showSkipControls are mutually exclusive. showSkipControls will be set to false.',
 			);
 			config = { ...config, showSkipControls: false };
+		}
+		if (config.skipInterval) {
+			// Warn if deprecated skipInterval configuration was used
+			console.warn(
+				'[react-native-audio-pro]: skipInterval is deprecated and will be removed in a future release. Use `skipIntervalMs` instead.',
+			);
+			// Remove deprecated skipInterval property, and transform to value in milliseconds
+			const { skipInterval: skipIntervalDeprecated, ...fixedConfig } = config;
+			config = { ...fixedConfig, skipIntervalMs: skipIntervalDeprecated * 1000 };
 		}
 		setConfigureOptions(config);
 		setDebug(!!options.debug);

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,10 @@ export type AudioProConfigureOptions = {
 	progressIntervalMs?: number;
 	showNextPrevControls?: boolean;
 	showSkipControls?: boolean;
+	skipIntervalMs?: number;
+	/**
+	 * @deprecated use skipIntervalMs instead
+	 */
 	skipInterval?: number;
 };
 

--- a/src/values.ts
+++ b/src/values.ts
@@ -76,9 +76,9 @@ export enum AudioProAmbientEventType {
 }
 
 /**
- * Skip interval in seconds
+ * Default skip interval in milliseconds (10 seconds)
  */
-export const DEFAULT_SKIP_INTERVAL = 10;
+export const DEFAULT_SKIP_INTERVAL_MS = 10000;
 
 /**
  * Default configuration options for the audio player
@@ -96,6 +96,6 @@ export const DEFAULT_CONFIG: AudioProConfigureOptions = {
 	showNextPrevControls: true,
 	/** Whether to show skip forward/back controls in notification */
 	showSkipControls: false,
-	/** Skip interval in seconds */
-	skipInterval: DEFAULT_SKIP_INTERVAL,
+	/** Interval in milliseconds for skip forward/back actions */
+	skipIntervalMs: DEFAULT_SKIP_INTERVAL_MS,
 };

--- a/src/values.ts
+++ b/src/values.ts
@@ -76,9 +76,9 @@ export enum AudioProAmbientEventType {
 }
 
 /**
- * Default skip interval in milliseconds (10 seconds)
+ * Default skip interval in milliseconds (30 seconds)
  */
-export const DEFAULT_SKIP_INTERVAL_MS = 10000;
+export const DEFAULT_SKIP_INTERVAL_MS = 30000;
 
 /**
  * Default configuration options for the audio player


### PR DESCRIPTION
Congrats on the v10 release and thanks again for all the hard work! I'd hoped to open this PR before 10 dropped, but obviously I was too slow :laughing: 

#### What
A few relatively minor changes here:

1. Deprecate `skipInterval` method and replace it with `skipIntervalMs`.
2. Introduce a console warning for the above, and convert the seconds value to milliseconds to prevent breakage of existing apps.
3. Fix the default skip interval values to match the documented defaults.

#### Why
1. Aside from `skipInterval`, every AudioPro method uses milliseconds for time/interval/duration values (see e.g. seek forward/back/to, progressInterval, playback timings etc). This inconsistency could feel a little unintuitive for library consumers.
2. The `skipInterval` configuration option is likely to be used in conjunction with the `seekForward` and `seekBack` methods (i.e. app developers will likely wish to match their in-app seeking behaviour with the system skip button behaviour). The seek methods all expect values in milliseconds, so developers currently have to take care to transform between these different units for different uses.

I noticed that the original PR was "vibe-coded", which I assume is why this divergence from the rest of the library's methods was introduced :wink: